### PR TITLE
change details API to use PubMed Central article format

### DIFF
--- a/search.js
+++ b/search.js
@@ -60,8 +60,8 @@ let pubMedApi = {
     },
 
     fetchResultDetail: function (pmcId, callback) {
-        let uri = `${eUtilsBaseUrl}efetch.fcgi?db=pubmed&id=${pmcId}&retmode=xml`;
-        console.log(`fetching details at ${uri}`);
+        let uri = `${eUtilsBaseUrl}efetch.fcgi?db=pmc&id=${pmcId}&retmode=xml`;
+        console.log(`fetching details for ${pmcId} at ${uri}`);
         httpRequest(uri, null, (err, response, body) => {
 
             let result = {};
@@ -84,16 +84,27 @@ let pubMedApi = {
 
                 try {
                     parsed
-                        .PubmedArticle
-                        .MedlineCitation
-                        .Article
-                        .Abstract
-                        .AbstractText
-                        .forEach((abstractTxt) => {
-                            console.log(abstractTxt['@'].Label); // the abstract type
-                            console.log(abstractTxt['#']); // the abstract's text
-                            result[abstractTxt['@'].Label.toLowerCase()] = abstractTxt['#'];
+                        .article
+                        .front
+                        ['article-meta']
+                        .abstract
+                        .sec
+                        .forEach(s => {
+                            console.log(`${s.title.toLowerCase()} ${s.p['#']}`);
+                            result[s.title.toLowerCase()] = s.p["#"];
                         });
+
+                    // parsed
+                    //     .PubmedArticle
+                    //     .MedlineCitation
+                    //     .Article
+                    //     .Abstract
+                    //     .AbstractText
+                    //     .forEach((abstractTxt) => {
+                    //         console.log(abstractTxt['@'].Label); // the abstract type
+                    //         console.log(abstractTxt['#']); // the abstract's text
+                    //         result[abstractTxt['@'].Label.toLowerCase()] = abstractTxt['#'];
+                    //     });
                 }
                 catch(e) {
                     console.log(`error extracting the abstract's text from the document ${e}`);

--- a/views/results.pug
+++ b/views/results.pug
@@ -27,7 +27,7 @@ block scripts
                 if($(this).find(".fa-angle-down").length > 0) {
                     var eBody = $(this).closest("div.list-group-item").find("#expansionBody");
                     // Get the content from back end
-                    $.get('/detail/' + $(this).find("#pmid").val(), null, function(response) {
+                    $.get('/detail/' + $(this).find("#uid").val(), null, function(response) {
                         if (response.error) {
                             eBody.text(response.error);
                         } else {
@@ -68,15 +68,15 @@ block content
                             div(class="list-view-pf-checkbox")
                                 input(type="checkbox")
                             div(class="list-view-pf-main-info")
-                                div(class="list-view-pf-body")
+                                div(class="list-group-item-heading")
+                                    a(target="_blank" href=`https://www.ncbi.nlm.nih.gov/pmc/articles/PMC${item.uid}`) #{item.uid}
+                                    input(type="hidden" id="uid" value=`${item.uid}`)
+                                    each articleid in item.articleids
+                                        if articleid.idtype == "pmid"
+                                            br
+                                            a(target="_blank" href=`https://www.ncbi.nlm.nih.gov/pubmed/${articleid.value}`) #{articleid.value}
+                            div(class="list-view-pf-body")
                                     div(class="list-view-pf-description")
-                                        div(class="list-group-item-heading")
-                                            a(target="_blank" href=`https://www.ncbi.nlm.nih.gov/pmc/articles/PMC${item.uid}`) #{item.uid}
-                                            each articleid in item.articleids
-                                                if articleid.idtype == "pmid"
-                                                    br
-                                                    a(target="_blank" href=`/detail/${articleid.value}`) #{articleid.value}
-                                                    input(type="hidden" id="pmid" value=`${articleid.value}`)
                                         div(class="list-group-item-text")
                                             span
                                                 strong= item.title


### PR DESCRIPTION
use the PMC ID when fetching details for an article. This may not work for all formats (particularly if the article is not a RCT). Error handling/handling alternative formats to be addressed in a subsequent PR.