### PR TITLE
Changes to load additional result rows on demand

### DIFF
--- a/less/pmstyles.less
+++ b/less/pmstyles.less
@@ -31,6 +31,9 @@
     padding-top: 14px;
 }
 
+.expansion-body {
+    padding-top: 4px;
+}
 @-moz-document url-prefix() {
     .pm-list-row-authors {
         width: 400px;

--- a/public/scripts/pubminer.js
+++ b/public/scripts/pubminer.js
@@ -1,0 +1,115 @@
+// pubminer.js
+//
+// JavaScript to support pubminer UI results page
+
+// expand the row and fill with content from the backend
+// code adapted from samples on PatternFly.org
+$.fn.addArrowClickHandler = function() {
+    this.click(function(event){
+        if(!$(event.target).is("button, a, input, .fa-ellipsis-v")){
+            $(this).find(".fa-angle-right").toggleClass("fa-angle-down")
+            .end().parent().toggleClass("list-view-pf-expand-active")
+            .find(".list-group-item-container").toggleClass("hidden");
+
+            if($(this).find(".fa-angle-down").length > 0) {
+                let expansionBody = $(this).closest("div.list-group-item").find("div.expansion-body");
+                let uidValue = $(this).closest("div.list-group-item").find("input.uid").val();
+                // Get the content from back end
+                $.get('/detail/' + uidValue, null, function(response) {
+                    if (response.error) {
+                        expansionBody.text(response.error);
+                    } else {
+                        expansionBody.html("");
+                        for (var key in response) {
+                            if (response.hasOwnProperty(key)) {
+                                expansionBody.append($("<strong>", {html: key}));
+                                expansionBody.append(" " + response[key]);
+                                expansionBody.append("<br/>")
+                            }
+                        }
+                    }
+                });
+            }
+        } else {
+        }
+    });
+};
+
+// close the expanded row
+// code adapted from samples on PatternFly.org
+$.fn.addCloseRowHandler = function() {
+    this.on("click", function (){
+        $(this).parent().addClass("hidden")
+        .parent().removeClass("list-view-pf-expand-active")
+        .find(".fa-angle-right").removeClass("fa-angle-down");
+    });
+};
+
+// add styling to rows that have been check-selected
+// code adapted from samples on PatternFly.org
+$.fn.addRowCheckboxHandler = function() {
+    this.change(function (e) {
+        if ($(this).is(":checked")) {
+            $(this).closest('.list-group-item').addClass("active");
+        } else {
+            $(this).closest('.list-group-item').removeClass("active");
+        }
+    });
+};
+
+$(document).ready(function() {
+
+    // the next three function calls add handlers to the rows initially displayed.
+
+    // row checkbox selection
+    $("input[type='checkbox']").addRowCheckboxHandler();
+
+    // click the list-view heading then expand a row
+    $(".list-group-item-header").addArrowClickHandler();
+
+    // click the close button, hide the expand row and remove the active status
+    $(".list-group-item-container .close").addCloseRowHandler();
+
+    // handle new rows added to display
+    $("#moreButton").click(function() {
+
+        let params = { start: $("#nextRow").val(),
+                       count: $("#rowCount").val()};
+
+        // make sure there are more rows more to get
+        if (params.start != 0) {
+
+            $.get('/results/' + $("#webenv").val() + '/' + $("#querykey").val(),
+                params, function(response) {
+
+                    let newRows = $.parseHTML(response)
+
+                    // add handlers to the new rows
+
+                    // row checkbox selection
+                    $(newRows).find("input[type='checkbox']").addRowCheckboxHandler();
+
+                    // click the list-view heading then expand a row
+                    $(newRows).find(".list-group-item-header").addArrowClickHandler();
+
+                    // click the close button, hide the expand row and remove the active status
+                    $(newRows).find(".list-group-item-container .close").addCloseRowHandler();
+
+                    $("#resultRows").append(newRows);
+
+                    // bump up the counter for more rows
+                    var rowCount = parseInt($("#rowCount").val(), 10);
+                    var nextRow = parseInt($("#nextRow").val(), 10) + rowCount;
+                    // if we got back less than we asked for, then there are no more to get.
+                    if (newRows.length < rowCount) {
+                        nextRow = 0;
+                        rowCount = 0;
+                    }
+
+                    // set the page values for the next row retrieval batch
+                    $("#nextRow").val(nextRow);
+                    $("#rowCount").val(rowCount);
+                });
+        }
+    });
+});

--- a/routes/results.js
+++ b/routes/results.js
@@ -4,11 +4,42 @@ var pubMedQuery = require('../search');
 
 router.get('/', (request, response) => {
 
+    const initialRowRequestSize = 20;
+
     // search PubMed for results matching the search terms
     pubMedQuery.search(request.query.searchTerm, (queryResult) => {
 
+        if (queryResult.itemsFound == 0) {
+            // Render the 'results' view
+            response.render('results', {"results": {items: []},
+                                        "qryResult": queryResult});
+        } else {
+            // Get summaries for the first set of result rows
+            pubMedQuery.getSummaries(queryResult.webenv, queryResult.querykey, 0, initialRowRequestSize, (results) => {
+
+                var nextRow = initialRowRequestSize + 1;
+                var rowCount = initialRowRequestSize;
+                if (queryResult.itemsFound < initialRowRequestSize) {
+                    nextRow = 0;
+                    rowCount = 0;
+                }
+                // Render the 'results' view using query results
+                response.render('results', {"results": results,
+                                            "qryResult": queryResult,
+                                            "nextRow": nextRow,
+                                            "rowCount": rowCount});
+            });
+        }
+    });
+});
+
+router.get('/:webenv/:querykey', function(req, res, next) {
+
+    // Get summaries for result rows
+    pubMedQuery.getSummaries(req.params.webenv, req.params.querykey, req.query.start, req.query.count, (results) => {
+
         // Render the 'list' view using query results, if any
-        response.render('results', {"results": queryResult});
+        res.render('resultRows', { "results": results });
     });
 
 });

--- a/views/resultRow.pug
+++ b/views/resultRow.pug
@@ -13,7 +13,7 @@ div(class='list-group-item')
             div(class="list-view-pf-body")
                 div(class="list-view-pf-description")
                     //- Hidden input field so we can retrieve a PMC id
-                    input(type="hidden" id="uid" value=`${item.uid}`)
+                    input(type="hidden" class="uid" value=item.uid)
                     div(class="list-group-item-text")
                         //- Title
                         span
@@ -21,7 +21,6 @@ div(class='list-group-item')
                         //- Authors list, comma separated
                         - var authorList = item.authors.map(function(author){if(author.authtype == "Author") return author.name;}).join(', ');
                         div(class="pm-list-row-authors" title=`${authorList}`)= authorList
-                input(type="hidden" id="uid" value=`${item.uid}`)
                 div(class="list-view-pf-additional-info")
                     div(class="list-view-pf-additional-info-item")
                         span(class="pficon pficon-screen")
@@ -41,16 +40,16 @@ div(class='list-group-item')
             span(class="pficon pficon-close")
         div(style="padding-bottom: 8px")
             if (item.pubdate) 
-                span Publication Date:
+                span(style="padding-right: 10px") Publication Date:
                     span(style="padding-left: 3px; font-weight: bold")= item.pubdate
             each articleid in item.articleids
                 if (articleid.idtype == "pmcid") && (articleid.value != 0)
-                    span(style="padding-left: 10px") PubMed Central:&nbsp;
-                    a(target="_blank" href=`https://www.ncbi.nlm.nih.gov/pmc/${articleid.value}`) #{articleid.value}
+                    span(style="padding-right: 10px") PubMed Central:&nbsp;
+                        a(target="_blank" href=`https://www.ncbi.nlm.nih.gov/pmc/${articleid.value}`) #{articleid.value}
                 if (articleid.idtype == "pmid") && (articleid.value != 0)
-                    span(style="padding-left: 10px") PubMed:&nbsp;
-                    a(target="_blank" href=`https://www.ncbi.nlm.nih.gov/pubmed/${articleid.value}`) #{articleid.value}
+                    span(style="padding-right: 10px") PubMed:&nbsp;
+                        a(target="_blank" href=`https://www.ncbi.nlm.nih.gov/pubmed/${articleid.value}`) #{articleid.value}
         //- Expansion Body gets replaced with content from an API call.
-        div(class="expansion-body" id="expansionBody")
+        div(class="expansion-body")
             .spinner
             .loading-text Loading

--- a/views/resultRows.pug
+++ b/views/resultRows.pug
@@ -1,0 +1,2 @@
+each item in results.items
+    include resultRow

--- a/views/results.pug
+++ b/views/results.pug
@@ -6,59 +6,17 @@
 extends layout.pug
 block scripts
     script(src="bower_components/jquery/dist/jquery.min.js")
-    script(type="text/javascript").
-        $(document).ready(function() {
-            // Row Checkbox Selection
-            $("input[type='checkbox']").change(function (e) {
-                if ($(this).is(":checked")) {
-                    $(this).closest('.list-group-item').addClass("active");
-                } else {
-                    $(this).closest('.list-group-item').removeClass("active");
-                }
-            });
-
-            // click the list-view heading then expand a row
-            $(".list-group-item-header").click(function(event){
-                if(!$(event.target).is("button, a, input, .fa-ellipsis-v")){
-                    $(this).find(".fa-angle-right").toggleClass("fa-angle-down")
-                    .end().parent().toggleClass("list-view-pf-expand-active")
-                    .find(".list-group-item-container").toggleClass("hidden");
-
-                    if($(this).find(".fa-angle-down").length > 0) {
-                        var eBody = $(this).closest("div.list-group-item").find("#expansionBody");
-                        // Get the content from back end
-                        $.get('/detail/' + $(this).find("#uid").val(), null, function(response) {
-                            if (response.error) {
-                                eBody.text(response.error);
-                            } else {
-                                eBody.html("");
-                                for (var key in response) {
-                                    if (response.hasOwnProperty(key)) {
-                                        eBody.append($("<strong>", {html: key}));
-                                        eBody.append(" " + response[key]);
-                                        eBody.append("<br/>")
-                                    }
-                                }
-                            }
-                        });
-                    }
-                } else {
-                }
-            })
-
-            // click the close button, hide the expand row and remove the active status
-            $(".list-group-item-container .close").on("click", function (){
-                $(this).parent().addClass("hidden")
-                .parent().removeClass("list-view-pf-expand-active")
-                .find(".fa-angle-right").removeClass("fa-angle-down");
-            })
-        });
+    script(src="scripts/pubminer.js")
 block content
     if results.items.length == 0
-        p(style='margin: 24px 0px 0px 20px; font-style: italic;') No results found for "#{results.searchTerm}"
+        p(style='margin: 24px 0px 0px 20px; font-style: italic;') No results found for "#{qryResult.searchTerm}"
     else
-        p(style='margin: 24px 0px 0px 20px; font-style: italic;') Displaying #{results.itemsReturned} of #{results.itemsFound} results found for "#{results.searchTerm}"
+        p(style='margin: 24px 0px 0px 20px; font-style: italic;') Displaying #{qryResult.itemsReturned} of #{qryResult.itemsFound} results found for "#{qryResult.searchTerm}"
+        input(type="hidden" id="webenv" value=qryResult.webenv)
+        input(type="hidden" id="querykey" value=qryResult.querykey)
+        input(type="hidden" id="nextRow" value=nextRow)
+        input(type="hidden" id="rowCount" value=rowCount)
         div(class='container-fluid')
-            div(class='list-group list-view-pf list-view-pf-view')
-                each item in results.items
-                    include resultRow
+            div(id="resultRows" class='list-group list-view-pf list-view-pf-view')
+                include resultRows
+        button(id="moreButton" class="btn btn-warning") Show More


### PR DESCRIPTION
These changes support demand-loading additional result rows and comprise the following tasks:
- Separating the code in search.js that retrieves summaries from the code that executes searches. Necessary because we need to request additional summaries without doing a new search.
- Modifying routes/results.js so that the initial search request performs the search and separately requests the first batch of summaries. Also adds an additional route to support getting the next batch of summaries.
- Creating a new template file, resultRows.pug, and modifying template results.pug. The iteration of result rows needs to be separate from the result page so we can render the additional batches.
- Creating a new file, pubminer.js, for JavaScript used by the results page
- Making minor changes to less/pmstyles.less and views/resultRow.pug