### PR TITLE
return all pubmed results in correct order

### DIFF
--- a/services/DemographicsService.js
+++ b/services/DemographicsService.js
@@ -29,16 +29,10 @@ class DemographicsService {
                     ConsistentRead: false,
                     Keys: pmcids
                         .filter(id => id != null)
-                        .map((id) => {
-                            return {
-                                pmcid: id
-                            }
-                        })
+                        .map(id => ({ pmcid: id }))
                 }
             }
         };
-
-        console.debug(`sending query ${JSON.stringify(query)}`);
 
         return this
             .docClient
@@ -49,15 +43,15 @@ class DemographicsService {
                 .Responses
                 .demographics
                 .filter(item => item.errorStatus == null)
-                .map(item => {
+                .reduce((acc, item) => {
                     console.log(`got ${JSON.stringify(item)} from DB`);
-                    return {
+                    acc[item.pmid] = {
                         pmcid: item.pmcid,
-                        pmid: item.pmid,
                         sentences: item.sentences,
                         date_process: item.date_processed
                     };
-                });
+                    return acc;
+                }, {});
             },
             err => {
                 console.log(`dynamo batchGet error: ${err}`)


### PR DESCRIPTION
This change will display all pub med results rather than filtering to a subset that is in the database (since doing that correctly is complicated). This issue also addresses #43 by making sure the results display in the order returned by esummary.