### PR TITLE
Update "items displayed" count. Hide more button.

### DIFF
--- a/less/pmstyles.less
+++ b/less/pmstyles.less
@@ -16,7 +16,10 @@
 
 // PubMiner Styles
 @link-color: orange;
-
+.results-summary {
+    margin: 24px 0px 0px 20px;
+    font-style: italic;
+}
 .pm-list-row-authors {
     white-space: nowrap;
     overflow: hidden;
@@ -40,6 +43,15 @@
 .article-title {
     font-weight: bold;
 }
+.abstract-icon {
+    color: #8a0e0e;
+}
+.sentence-icon {
+    color: #154a7d;
+}
+.table-icon {
+    color: #117d48;
+}
 .demo-sentence-section {
     color: #154a7d;
     font-weight: bold;
@@ -47,7 +59,7 @@
 }
 @media (min-width: 992px) {
     .list-view-pf-additional-info {
-        width: 30%;
+        width: 10%;
     }
 }
 @-moz-document url-prefix() {

--- a/public/scripts/pubminer.js
+++ b/public/scripts/pubminer.js
@@ -120,15 +120,23 @@ $(document).ready(function() {
                     // bump up the counter for more rows
                     var rowCount = parseInt($("#rowCount").val(), 10);
                     var nextRow = parseInt($("#nextRow").val(), 10) + rowCount;
+                    var itemsLoaded = parseInt($("#itemsLoaded").val(), 10) + newRows.length;
                     // if we got back less than we asked for, then there are no more to get.
                     if (newRows.length < rowCount) {
                         nextRow = 0;
                         rowCount = 0;
+                        //TODO hide "more" button.
                     }
 
                     // set the page values for the next row retrieval batch
                     $("#nextRow").val(nextRow);
                     $("#rowCount").val(rowCount);
+                    $("#itemsLoaded").val(itemsLoaded);
+
+                    // update the banner
+                    var totalItems = $("#totalItems").val();
+                    var searchTerm = $("#searchTerm").val();
+                    $(".results-summary").text(`Displaying ${itemsLoaded} of ${totalItems} results found for "${searchTerm}"`)
                 });
         }
     });

--- a/public/scripts/pubminer.js
+++ b/public/scripts/pubminer.js
@@ -93,51 +93,49 @@ $(document).ready(function() {
     // handle new rows added to display
     $("#moreButton").click(function() {
 
-        let params = { start: $("#nextRow").val(),
-                       count: $("#rowCount").val()};
+        let params = { start: $("#itemsLoaded").val()};
 
-        // make sure there are more rows more to get
-        if (params.start != 0) {
+        $.get('/results/' + $("#webenv").val() + '/' + $("#querykey").val(),
+            params, function(response) {
 
-            $.get('/results/' + $("#webenv").val() + '/' + $("#querykey").val(),
-                params, function(response) {
+                let newRows = $.parseHTML(response)
 
-                    let newRows = $.parseHTML(response)
+                // add handlers to the new rows
 
-                    // add handlers to the new rows
+                // row checkbox selection
+                $(newRows).find("input[type='checkbox']").addRowCheckboxHandler();
 
-                    // row checkbox selection
-                    $(newRows).find("input[type='checkbox']").addRowCheckboxHandler();
+                // click the list-view heading then expand a row
+                $(newRows).find(".list-group-item-header").addArrowClickHandler();
 
-                    // click the list-view heading then expand a row
-                    $(newRows).find(".list-group-item-header").addArrowClickHandler();
+                // click the close button, hide the expand row and remove the active status
+                $(newRows).find(".list-group-item-container .close").addCloseRowHandler();
 
-                    // click the close button, hide the expand row and remove the active status
-                    $(newRows).find(".list-group-item-container .close").addCloseRowHandler();
+                // add the rows to the page
+                $("#resultRows").append(newRows);
 
-                    $("#resultRows").append(newRows);
+                // bump up the counter for more rows
+                let itemsLoaded = parseInt($("#itemsLoaded").val(), 10) + newRows.length;
+                $("#itemsLoaded").val(itemsLoaded);
 
-                    // bump up the counter for more rows
-                    var rowCount = parseInt($("#rowCount").val(), 10);
-                    var nextRow = parseInt($("#nextRow").val(), 10) + rowCount;
-                    var itemsLoaded = parseInt($("#itemsLoaded").val(), 10) + newRows.length;
-                    // if we got back less than we asked for, then there are no more to get.
-                    if (newRows.length < rowCount) {
-                        nextRow = 0;
-                        rowCount = 0;
-                        //TODO hide "more" button.
-                    }
+                // if we've gotten all the rows, hide the Show More button.
+                let totalItems = parseInt($("#totalItems").val(), 10);
+                if (itemsLoaded == totalItems) {
+                    $("#moreButton").hide();
+                }
 
-                    // set the page values for the next row retrieval batch
-                    $("#nextRow").val(nextRow);
-                    $("#rowCount").val(rowCount);
-                    $("#itemsLoaded").val(itemsLoaded);
+                // update the banner
+                let searchTerm = $("#termSearched").val();
+                $(".results-summary").text(`Displaying ${itemsLoaded} of ${totalItems} results found for "${searchTerm}"`)
+            });
 
-                    // update the banner
-                    var totalItems = $("#totalItems").val();
-                    var searchTerm = $("#searchTerm").val();
-                    $(".results-summary").text(`Displaying ${itemsLoaded} of ${totalItems} results found for "${searchTerm}"`)
-                });
-        }
     });
+
+    // hide the Show More button if there are no more rows to get
+    let itemsLoaded = parseInt($("#itemsLoaded").val(), 10);
+    let totalItems = parseInt($("#totalItems").val(), 10);
+    if (itemsLoaded == totalItems) {
+        $("#moreButton").hide();
+    }
+
 });

--- a/routes/results.js
+++ b/routes/results.js
@@ -2,9 +2,9 @@ var express = require("express");
 var router = express.Router();
 var pubMedQuery = require('../search');
 
-router.get('/', (request, response) => {
+const rowRequestSize = 20;
 
-    const initialRowRequestSize = 20;
+router.get('/', (request, response) => {
 
     // search PubMed for results matching the search terms
     pubMedQuery.search(request.query.searchTerm, (queryResult) => {
@@ -15,19 +15,11 @@ router.get('/', (request, response) => {
                                         "qryResult": queryResult});
         } else {
             // Get summaries for the first set of result rows
-            pubMedQuery.getSummaries(queryResult.webenv, queryResult.querykey, 0, initialRowRequestSize, (results) => {
+            pubMedQuery.getSummaries(queryResult.webenv, queryResult.querykey, 0, rowRequestSize, (results) => {
 
-                var nextRow = initialRowRequestSize + 1;
-                var rowCount = initialRowRequestSize;
-                if (queryResult.itemsFound < initialRowRequestSize) {
-                    nextRow = 0;
-                    rowCount = 0;
-                }
                 // Render the 'results' view using query results
                 response.render('results', {"results": results,
-                                            "qryResult": queryResult,
-                                            "nextRow": nextRow,
-                                            "rowCount": rowCount});
+                                            "qryResult": queryResult});
             });
         }
     });
@@ -36,7 +28,7 @@ router.get('/', (request, response) => {
 router.get('/:webenv/:querykey', function(req, res, next) {
 
     // Get summaries for result rows
-    pubMedQuery.getSummaries(req.params.webenv, req.params.querykey, req.query.start, req.query.count, (results) => {
+    pubMedQuery.getSummaries(req.params.webenv, req.params.querykey, req.query.start, rowRequestSize, (results) => {
 
         // Render the 'list' view using query results, if any
         res.render('resultRows', { "results": results });

--- a/views/resultRows.pug
+++ b/views/resultRows.pug
@@ -22,11 +22,15 @@ each item in results.items
                     //- Icons
                     div(class="list-view-pf-additional-info")
                         div(class="list-view-pf-additional-info-item")
-                            span(class="pficon pficon-screen")
+                            span(class="fa fa-list abstract-icon")
                             span Abstract
                         if item.sentences
                             div(class="list-view-pf-additional-info-item")
-                                span(class="pficon pficon-user")
-                                span= item.sentences.length + " Sentences" 
+                                span(class="pficon pficon-users sentence-icon")
+                                span= item.sentences.length + " Sentences"
+                        if item.table-one 
+                            div(class="list-view-pf-additional-info-item")
+                                span(class="fa fa-table table-icon")
+                                span Table 1
         //- Row expansion area
         include resultRowExpansion 

--- a/views/results.pug
+++ b/views/results.pug
@@ -8,13 +8,16 @@ block scripts
     script(src="scripts/pubminer.js")
 block content
     if results.items.length == 0
-        p(style='margin: 24px 0px 0px 20px; font-style: italic;') No results found for "#{qryResult.searchTerm}"
+        p(class='results-summary') No results found for "#{qryResult.searchTerm}"
     else
-        p(style='margin: 24px 0px 0px 20px; font-style: italic;') Displaying #{qryResult.itemsReturned} of #{qryResult.itemsFound} results found for "#{qryResult.searchTerm}"
         input(type="hidden" id="webenv" value=qryResult.webenv)
         input(type="hidden" id="querykey" value=qryResult.querykey)
         input(type="hidden" id="nextRow" value=nextRow)
         input(type="hidden" id="rowCount" value=rowCount)
+        input(type="hidden" id="itemsLoaded" value=qryResult.itemsReturned)
+        input(type="hidden" id="totalItems" value=qryResult.itemsFound)
+        input(type="hidden" id="searchTerm" value=qryResult.searchTerm)
+        p(class='results-summary') Displaying #{qryResult.itemsReturned} of #{qryResult.itemsFound} results found for "#{qryResult.searchTerm}"
         div(class='container-fluid')
             div(id="resultRows" class='list-group list-view-pf list-view-pf-view')
                 include resultRows

--- a/views/results.pug
+++ b/views/results.pug
@@ -12,12 +12,10 @@ block content
     else
         input(type="hidden" id="webenv" value=qryResult.webenv)
         input(type="hidden" id="querykey" value=qryResult.querykey)
-        input(type="hidden" id="nextRow" value=nextRow)
-        input(type="hidden" id="rowCount" value=rowCount)
-        input(type="hidden" id="itemsLoaded" value=qryResult.itemsReturned)
+        input(type="hidden" id="itemsLoaded" value=results.items.length)
         input(type="hidden" id="totalItems" value=qryResult.itemsFound)
-        input(type="hidden" id="searchTerm" value=qryResult.searchTerm)
-        p(class='results-summary') Displaying #{qryResult.itemsReturned} of #{qryResult.itemsFound} results found for "#{qryResult.searchTerm}"
+        input(type="hidden" id="termSearched" value=qryResult.searchTerm)
+        p(class='results-summary') Displaying #{results.items.length} of #{qryResult.itemsFound} results found for "#{qryResult.searchTerm}"
         div(class='container-fluid')
             div(id="resultRows" class='list-group list-view-pf list-view-pf-view')
                 include resultRows


### PR DESCRIPTION
This check-in comprises these changes:
* Update "items displayed" when Show More is pressed.
* Hide "Show More" when there are no more rows to display.
* Simplify the mechanism for keeping track of item count.
* Fix a bug due to not recognizing zero-based result indexing (we were always dropping the last item).
* Fix retmax at 20. We can make this configurable.
* Change row icons
* Add a row icon for table 1. Won't be displayed until we have this data in our query results.
